### PR TITLE
Fix margin property on h1

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,7 +6,7 @@ body{
 }
 
 h1{
-    margin-top: 50px auto 0 auto;
+    margin: 50px auto 0 auto;
     font-size: 5.625rem;
     font-family: 'Sacramento', cursive;
     color: #66BFBF;


### PR DESCRIPTION
## Summary
- fix CSS margin syntax for the h1 element

## Testing
- `git show -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684aabe45cb8832892090cc914f34b49